### PR TITLE
Django2 support.

### DIFF
--- a/timed_auth_token/migrations/0001_initial.py
+++ b/timed_auth_token/migrations/0001_initial.py
@@ -19,7 +19,7 @@ class Migration(migrations.Migration):
                 ('created', models.DateTimeField(auto_now_add=True)),
                 ('last_used', models.DateTimeField(auto_now=True)),
                 ('expires', models.DateTimeField(blank=True)),
-                ('user', models.ForeignKey(to=settings.AUTH_USER_MODEL)),
+                ('user', models.ForeignKey(to=settings.AUTH_USER_MODEL, on_delete=models.CASCADE)),
             ],
         ),
     ]

--- a/timed_auth_token/models.py
+++ b/timed_auth_token/models.py
@@ -30,7 +30,7 @@ class TimedAuthToken(models.Model):
     last_used = models.DateTimeField(auto_now=True)
     expires = models.DateTimeField(blank=True)
 
-    user = models.ForeignKey(settings.AUTH_USER_MODEL)
+    user = models.ForeignKey(settings.AUTH_USER_MODEL, on_delete=models.CASCADE)
 
     def __str__(self):
         return 'Token for %s, created %s, expires %s' % (


### PR DESCRIPTION
The on_delete argument for ForeignKey and OneToOneField is now required in models and migrations.
([django release notes](https://docs.djangoproject.com/en/2.0/releases/2.0/#features-removed-in-2-0))